### PR TITLE
websockets - graceful reload

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,6 +90,12 @@ Synopsis
         return ngx.exit(444)
     end
 
+    local ngx_exit = ngx.worker.exiting()
+    if ngx_exit then
+        ngx.log(ngx.ERR, "closing open websockets - nginx worker exiting")
+        wb:send_close()
+    end
+
     if typ == "close" then
         -- send a close frame back:
 


### PR DESCRIPTION
on primary websocket loop, catch ngx exit and close out open websockets to gracefully reload.
