### PR TITLE
Support for custom headers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -378,6 +378,9 @@ An optional Lua table can be specified as the last argument to this method to sp
 * `origin`
 
     Specifies the value of the `Origin` request header.
+* `headers`
+
+    Specifies a table of request headers.
 * `pool`
 
     Specifies a custom name for the connection pool being used. If omitted, then the connection pool name will be generated from the string template `<host>:<port>`.

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -98,9 +98,17 @@ function _M.connect(self, uri, opts)
         path = "/"
     end
 
-    local ssl_verify, proto_header, origin_header, sock_opts = false
+    local ssl_verify, proto_header, origin_header, custom_header, sock_opts = false
 
     if opts then
+        local headers = opts.headers
+        if headers then
+            custom_header = ""
+            for field,value in pairs(headers) do
+                custom_header = custom_header .. "\r\n" .. field .. ": " .. value
+            end
+        end
+
         local protos = opts.protocols
         if protos then
             if type(protos) == "table" then
@@ -173,6 +181,7 @@ function _M.connect(self, uri, opts)
     local key = encode_base64(bytes)
     local req = "GET " .. path .. " HTTP/1.1\r\nUpgrade: websocket\r\nHost: "
                 .. host .. ":" .. port
+                .. (custom_header or "")
                 .. "\r\nSec-WebSocket-Key: " .. key
                 .. (proto_header or "")
                 .. "\r\nSec-WebSocket-Version: 13"

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -104,7 +104,7 @@ function _M.connect(self, uri, opts)
         local headers = opts.headers
         if headers then
             custom_header = ""
-            for field,value in pairs(headers) do
+            for field, value in ipairs(headers) do
                 custom_header = custom_header .. "\r\n" .. field .. ": " .. value
             end
         end


### PR DESCRIPTION
For example can pass custom headers (in this case the Cookie) in the client websocket by doing
``wb:connect(uri, {headers = { Cookie = 'mycookie' })``

Note that with this option the options *origin* and *protocols* could be removed and , then the header generation code simplified, however I did not want to break API compability.

This implements #23