### PR TITLE
support cookie on opening websocket handshake

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -385,6 +385,9 @@ An optional Lua table can be specified as the last argument to this method to sp
 * `pool`
 
     Specifies a custom name for the connection pool being used. If omitted, then the connection pool name will be generated from the string template `<host>:<port>`.
+* `cookies`
+
+    Specifies the cookies of websocket handshake HTTP request. Cookies should be separated by semi-colon.
 * `ssl_verify`
 
     Specifies whether to perform SSL certificate verification during the

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -18,6 +18,7 @@ local encode_base64 = ngx.encode_base64
 local concat = table.concat
 local char = string.char
 local str_find = string.find
+local str_len = string.len
 local rand = math.random
 local rshift = bit.rshift
 local band = bit.band
@@ -99,6 +100,7 @@ function _M.connect(self, uri, opts)
     end
 
     local ssl_verify, proto_header, origin_header, sock_opts = false
+    local origin_cookies
 
     if opts then
         local protos = opts.protocols
@@ -128,6 +130,11 @@ function _M.connect(self, uri, opts)
             end
             ssl_verify = true
         end
+
+        if opts.cookies and str_len(opts.cookies) > 0 then
+            origin_cookies = "\r\nCookie: " .. opts.cookies
+        end
+
     end
 
     local ok, err
@@ -177,6 +184,7 @@ function _M.connect(self, uri, opts)
                 .. (proto_header or "")
                 .. "\r\nSec-WebSocket-Version: 13"
                 .. (origin_header or "")
+                .. (origin_cookies or "")
                 .. "\r\nConnection: Upgrade\r\n\r\n"
 
     local bytes, err = sock:send(req)


### PR DESCRIPTION
This patch allows user to specify cookies when initiating a websocket connection. According to the web socket specification, setting cookie is allowed and many applications depends on this feature. This option is totally optional and as a result it doesn't affect any existing functionality if this option is absent.

Please consider accept this pull request. Thanks!