### PR TITLE
Feature: Support connecting to unix sockets

### DIFF
--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -169,18 +169,10 @@ function _M.connect(self, uri, opts)
     end
 
     local ok, err
-    if sock_opts then
-        if is_unix then
-            ok, err = sock:connect(host, sock_opts)
-        else
-            ok, err = sock:connect(host, port, sock_opts)
-        end
+    if is_unix then
+        ok, err = sock:connect(host, sock_opts)
     else
-        if is_unix then
-            ok, err = sock:connect(host)
-        else
-            ok, err = sock:connect(host, port)
-        end
+        ok, err = sock:connect(host, port, sock_opts)
     end
     if not ok then
         return nil, "failed to connect: " .. err

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -14,6 +14,7 @@ local _send_frame = wbproto.send_frame
 local new_tab = wbproto.new_tab
 local tcp = ngx.socket.tcp
 local re_match = ngx.re.match
+local re_find  = ngx.re.find
 local encode_base64 = ngx.encode_base64
 local concat = table.concat
 local char = string.char
@@ -74,7 +75,16 @@ function _M.connect(self, uri, opts)
         return nil, "not initialized"
     end
 
-    local m, err = re_match(uri, [[^(wss?)://([^:/]+)(?::(\d+))?(.*)]], "jo")
+    local is_unix = false
+
+    local m, err
+    if re_find(uri, "unix:") then
+        is_unix = true
+        m, err = re_match(uri, [[^(wss?)://(unix:[^:]+):()(.*)]], "jo")
+    else
+        m, err = re_match(uri, [[^(wss?)://([^:/]+)(?::(\d+))?(.*)]], "jo")
+    end
+
     if not m then
         if err then
             return nil, "failed to match the uri: " .. err
@@ -158,7 +168,20 @@ function _M.connect(self, uri, opts)
         end
     end
 
-    local ok, err = sock:connect(host, port, sock_opts)
+    local ok, err
+    if sock_opts then
+        if is_unix then
+            ok, err = sock:connect(host, sock_opts)
+        else
+            ok, err = sock:connect(host, port, sock_opts)
+        end
+    else
+        if is_unix then
+            ok, err = sock:connect(host)
+        else
+            ok, err = sock:connect(host, port)
+        end
+    end
     if not ok then
         return nil, "failed to connect: " .. err
     end
@@ -204,7 +227,7 @@ function _M.connect(self, uri, opts)
 
     local key = encode_base64(bytes)
     local req = "GET " .. path .. " HTTP/1.1\r\nUpgrade: websocket\r\nHost: "
-                .. host .. ":" .. port
+                .. (is_unix and "unix_sock" or host .. ":" .. port)
                 .. "\r\nSec-WebSocket-Key: " .. key
                 .. (proto_header or "")
                 .. "\r\nSec-WebSocket-Version: 13"


### PR DESCRIPTION
Support for unix sockets.

Had no idea what the host header should be, could substitute the "/"'s with "."'s of the host var and use that instead if it's prefered.

Used an empty capture group for the port, could change it to named captures.