### PR TITLE
feat(client) enhancements to connect()

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -394,6 +394,25 @@ SSL handshake if the `wss://` scheme is used.
 
     Specifies custom headers to be sent in the handshake request. The table is expected to contain strings in the format `{"a-header: a header value", "another-header: another header value"}`.
 
+* `host`
+
+    Specifies the value of the `Host` request header. If not provided, the
+    `Host` header will be derived from the hostname/address and port in the
+    connection URI.
+
+* `ssl_server_name`
+
+    Specifies the server name/SNI to use when performing the TLS handshake with
+    the server. If not provided, the `host` value or the `<host/addr>:<port>`
+    from the connection URI will be used.
+
+* `key`
+
+    Specifies the value of the `Sec-WebSocket-Key` request header. The value
+    should be a base64-encoded 16 byte value to conform to the client handshake
+    requirements of the [WebSocket RFC](https://datatracker.ietf.org/doc/html/rfc6455#section-4.1).
+    If not provided, a key is randomly generated.
+
 The SSL connection mode (`wss://`) requires at least `ngx_lua` 0.9.11 or OpenResty 1.7.4.1.
 
 [Back to TOC](#table-of-contents)

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -106,6 +106,7 @@ function _M.connect(self, uri, opts)
 
     local host
     local ssl_server_name
+    local key
 
     if opts then
         local protos = opts.protocols
@@ -143,6 +144,8 @@ function _M.connect(self, uri, opts)
         host = opts.host
 
         ssl_server_name = opts.ssl_server_name
+
+        key = opts.key
     end
 
     local ok, err
@@ -184,14 +187,17 @@ function _M.connect(self, uri, opts)
     -- do the websocket handshake:
     local host_header = host or (addr .. ":" .. port)
 
-    local bytes = char(rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1)
+    if not key then
+        local bytes = char(rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1)
 
-    local key = encode_base64(bytes)
+        key = encode_base64(bytes)
+    end
+
     local req = "GET " .. path .. " HTTP/1.1\r\nUpgrade: websocket\r\nHost: "
                 .. host_header
                 .. "\r\nSec-WebSocket-Key: " .. key

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -107,6 +107,7 @@ function _M.connect(self, uri, opts)
     local host
     local ssl_server_name
     local key
+    local keep_response
 
     if opts then
         local protos = opts.protocols
@@ -146,6 +147,8 @@ function _M.connect(self, uri, opts)
         ssl_server_name = opts.ssl_server_name
 
         key = opts.key
+
+        keep_response = opts.keep_response
     end
 
     local ok, err
@@ -218,6 +221,10 @@ function _M.connect(self, uri, opts)
     local header, err, partial = header_reader()
     if not header then
         return nil, "failed to receive response header: " .. err
+    end
+
+    if keep_response then
+        self.response = header
     end
 
     -- error("header: " .. header)

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -101,6 +101,7 @@ function _M.connect(self, uri, opts)
     local ssl_verify, headers, proto_header, origin_header, sock_opts = false
 
     local host
+    local ssl_server_name
 
     if opts then
         local protos = opts.protocols
@@ -139,6 +140,8 @@ function _M.connect(self, uri, opts)
         end
 
         host = opts.host
+
+        ssl_server_name = opts.ssl_server_name
     end
 
     local ok, err
@@ -152,10 +155,11 @@ function _M.connect(self, uri, opts)
     end
 
     if scheme == "wss" then
+        ssl_server_name = ssl_server_name or host or addr
         if not ssl_support then
             return nil, "ngx_lua 0.9.11+ required for SSL sockets"
         end
-        ok, err = sock:sslhandshake(false, host, ssl_verify)
+        ok, err = sock:sslhandshake(false, ssl_server_name, ssl_verify)
         if not ok then
             return nil, "ssl handshake failed: " .. err
         end

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -90,6 +90,10 @@ function _M.connect(self, uri, opts)
     -- ngx.say("host: ", host)
     -- ngx.say("port: ", port)
 
+    if scheme == "wss" and not ssl_support then
+        return nil, "ngx_lua 0.9.11+ required for SSL sockets"
+    end
+
     if not port then
         port = 80
     end
@@ -126,9 +130,6 @@ function _M.connect(self, uri, opts)
         end
 
         if opts.ssl_verify then
-            if not ssl_support then
-                return nil, "ngx_lua 0.9.11+ required for SSL sockets"
-            end
             ssl_verify = true
         end
 
@@ -156,9 +157,7 @@ function _M.connect(self, uri, opts)
 
     if scheme == "wss" then
         ssl_server_name = ssl_server_name or host or addr
-        if not ssl_support then
-            return nil, "ngx_lua 0.9.11+ required for SSL sockets"
-        end
+
         ok, err = sock:sslhandshake(false, ssl_server_name, ssl_verify)
         if not ok then
             return nil, "ssl handshake failed: " .. err

--- a/t/cs.t
+++ b/t/cs.t
@@ -6,7 +6,7 @@ use Protocol::WebSocket::Frame;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 4 + 4);
+plan tests => repeat_each() * (blocks() * 4);
 
 my $pwd = cwd();
 
@@ -2309,3 +2309,49 @@ SSL server name: test.com
 GET /c
 --- error_log
 key: y7KXwBSpVrxtkR0O+bQt+Q==
+
+
+
+=== TEST 35: keeping the server response
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
+            local opts = {
+                keep_response = true,
+            }
+            local ok, err = wb:connect(uri, opts)
+            if not ok then
+                ngx.say("failed to connect: " .. err)
+                return
+            end
+
+            local res = wb.response
+            if not res then
+                ngx.say("no response string")
+                return
+            end
+            ngx.say(res)
+        }
+    }
+
+    location = /s {
+        content_by_lua_block {
+            ngx.header["x-test"] = "test"
+            ngx.header["x-multi"] = { "one", "two" }
+
+            local server = require "resty.websocket.server"
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+        }
+    }
+--- request
+GET /c
+--- response_body_unlike
+no response string

--- a/t/cs.t
+++ b/t/cs.t
@@ -1872,8 +1872,8 @@ sub {
 --- request
 GET /c
 
---- error_log
-lua ssl certificate verify error: (18: self signed certificate)
+--- error_log eval
+qr/lua (ssl|tls) certificate verify error: \(18: self signed certificate\)/
 
 --- timeout: 10
 

--- a/t/cs.t
+++ b/t/cs.t
@@ -6,7 +6,7 @@ use Protocol::WebSocket::Frame;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 4 + 13);
+plan tests => repeat_each() * (blocks() * 4 + 4);
 
 my $pwd = cwd();
 
@@ -2271,3 +2271,41 @@ GET /c
 --- error_log
 host: <client.test>
 SSL server name: test.com
+
+
+
+=== TEST 34: overriding the Sec-WebSocket-Key header
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
+            local opts = {
+                key = "y7KXwBSpVrxtkR0O+bQt+Q==",
+            }
+            local ok, err = wb:connect(uri, opts)
+            if not ok then
+                ngx.say("failed to connect: " .. err)
+                return
+            end
+        }
+    }
+
+    location = /s {
+        content_by_lua_block {
+            local server = require "resty.websocket.server"
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "key: ", ngx.var.http_sec_websocket_key)
+        }
+    }
+--- request
+GET /c
+--- error_log
+key: y7KXwBSpVrxtkR0O+bQt+Q==


### PR DESCRIPTION
Very WIP--mostly creating this as a place to have some discussion.

## overriding some values in the handshake request
 
- [x] Host header
- [x] SNI
- [x] Sec-WebSocket-Key

I'm not sure if overriding Sec-WebSocket-Key is necessary or even a good idea, but being able to do so gives us the ability to make proxying code more transparent as we please.

## saving the upstream handshake response

This is something I didn't think of during the initial arch/design discussions but is necessary IMO, because without it we can't proxy the upstream's response headers downstream, which could be a blocker for some users when compared to `proxy_pass`.

The response-handling in the current code is very spartan:

https://github.com/openresty/lua-resty-websocket/blob/34f6b41e538151e7a5f013ff9709c1708a9958fa/lib/resty/websocket/client.lua#L202-L216

I'm not sure how much we should expand upon this within lua-resty-websocket itself. Thus far I've gone the route of minimal change and introduced a `keep_response` connect flag which prompts `client:connect()` to stash the raw response string, allowing the caller to read and parse it as desired (now that I write this, maybe it should be returned instead so that it can be gc-ed without having to resort to `client.response = nil`, which feels a little dirty).

The other side of the coin is "well, there are some FIXME's in here for more response validation, so maybe some of the response parsing should happen _within_ `client:connect()` in order to address those things". Not sure where to draw the line here on caller vs library responsibility for the chore of response-parsing.