### PR TITLE
optimization: check ssl_support early

### DIFF
--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -91,8 +91,13 @@ function _M.connect(self, uri, opts)
     -- ngx.say("host: ", host)
     -- ngx.say("port: ", port)
 
+    local ssl = scheme == "wss"
+    if ssl and not ssl_support then
+        return nil, "ngx_lua 0.9.11+ required for SSL sockets"
+    end
+
     if not port then
-        port = scheme == 'wss' and 443 or 80
+        port = ssl and 443 or 80
     end
 
     if path == "" then
@@ -141,9 +146,6 @@ function _M.connect(self, uri, opts)
         end
 
         if opts.ssl_verify or opts.server_name then
-            if not ssl_support then
-                return nil, "ngx_lua 0.9.11+ required for SSL sockets"
-            end
             ssl_verify = opts.ssl_verify
             server_name = opts.server_name or host
         end
@@ -172,10 +174,7 @@ function _M.connect(self, uri, opts)
         return 1
     end
 
-    if scheme == "wss" then
-        if not ssl_support then
-            return nil, "ngx_lua 0.9.11+ required for SSL sockets"
-        end
+    if ssl then
         if client_cert then
             ok, err = sock:setclientcert(client_cert, client_priv_key)
             if not ok then


### PR DESCRIPTION
Check the request scheme and `ssl_support` and exit early (before handling options) if needed.