### PR TITLE
feature: allow custom host header

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -447,6 +447,14 @@ SSL handshake if the `wss://` scheme is used.
     [ngx.ssl.parse_pem_priv_key](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ssl.md#parse_pem_priv_key) 
     function provided by lua-resty-core.
 
+* `host`
+
+    Specifies the value of the `Host` header sent in the handshake request. If not provided, the `Host` header will be derived from the hostname/address and port in the connection URI.
+
+* `server_name`
+
+    Specifies the server name (SNI) to use when performing the TLS handshake with the server. If not provided, the `host` value or the `<host/addr>:<port>` from the connection URI will be used.
+
 The SSL connection mode (`wss://`) requires at least `ngx_lua` 0.9.11 or OpenResty 1.7.4.1.
 
 [Back to TOC](#table-of-contents)

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -84,7 +84,7 @@ function _M.connect(self, uri, opts)
     end
 
     local scheme = m[1]
-    local host = m[2]
+    local addr = m[2]
     local port = m[3]
     local path = m[4]
 
@@ -102,6 +102,7 @@ function _M.connect(self, uri, opts)
     local ssl_verify, server_name, headers, proto_header, origin_header
     local sock_opts = {}
     local client_cert, client_priv_key
+    local host
 
     if opts then
         local protos = opts.protocols
@@ -140,12 +141,11 @@ function _M.connect(self, uri, opts)
                    "client_priv_key must be provided with client_cert")
         end
 
-        if opts.ssl_verify or opts.server_name then
-            if not ssl_support then
-                return nil, "ngx_lua 0.9.11+ required for SSL sockets"
-            end
-            ssl_verify = opts.ssl_verify
-            server_name = opts.server_name or host
+        ssl_verify = opts.ssl_verify
+
+        server_name = opts.server_name
+        if server_name ~= nil and type(server_name) ~= "string" then
+            return nil, "SSL server_name must be a string"
         end
 
         if opts.headers then
@@ -154,9 +154,14 @@ function _M.connect(self, uri, opts)
                 return nil, "custom headers must be a table"
             end
         end
+
+        host = opts.host
+        if host ~= nil and type(host) ~= "string" then
+            return nil, "custom host header must be a string"
+        end
     end
 
-    local ok, err = sock:connect(host, port, sock_opts)
+    local ok, err = sock:connect(addr, port, sock_opts)
     if not ok then
         return nil, "failed to connect: " .. err
     end
@@ -182,6 +187,9 @@ function _M.connect(self, uri, opts)
                 return nil, "failed to set TLS client certificate: " .. err
             end
         end
+
+        server_name = server_name or host or addr
+
         ok, err = sock:sslhandshake(false, server_name, ssl_verify)
         if not ok then
             return nil, "ssl handshake failed: " .. err
@@ -204,8 +212,11 @@ function _M.connect(self, uri, opts)
                        rand(256) - 1)
 
     local key = encode_base64(bytes)
+
+    local host_header = host or (addr .. ":" .. port)
+
     local req = "GET " .. path .. " HTTP/1.1\r\nUpgrade: websocket\r\nHost: "
-                .. host .. ":" .. port
+                .. host_header
                 .. "\r\nSec-WebSocket-Key: " .. key
                 .. (proto_header or "")
                 .. "\r\nSec-WebSocket-Version: 13"


### PR DESCRIPTION
:wave: This adds custom host header support to `client:connect()`. The value of `opts.host` is used for SNI as well (unless the caller _also_ provides `opts.server_name`).

I've also added documentation for the recently-added `server_name` option.

---

~~Note: for the sake of not having to clean up merge conflicts when rebasing later on, this has been based off of the branch from #74, since that PR is already approved. If this is not desired, let me know and I'll re-push this without 9a53b4233b829db99aa36d6c751380d6525d50ab.~~