### PR TITLE
support socket connection pool and fix repeated sslhandshake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 
 os: linux
 

--- a/README.markdown
+++ b/README.markdown
@@ -390,7 +390,7 @@ An optional Lua table can be specified as the last argument to this method to sp
   specify the size of the connection pool. If omitted and no
   `backlog` option was provided, no pool will be created. If omitted
   but `backlog` was provided, the pool will be created with a default
-  size equal to the value of the [lua_socket_pool_size](#lua_socket_pool_size)
+  size equal to the value of the [lua_socket_pool_size](https://github.com/openresty/lua-nginx-module/tree/master#lua_socket_pool_size)
   directive.
   The connection pool holds up to `pool_size` alive connections
   ready to be reused by subsequent calls to [connect](#client:connect), but

--- a/README.markdown
+++ b/README.markdown
@@ -385,6 +385,44 @@ An optional Lua table can be specified as the last argument to this method to sp
 * `pool`
 
     Specifies a custom name for the connection pool being used. If omitted, then the connection pool name will be generated from the string template `<host>:<port>`.
+* `pool_size`
+
+  specify the size of the connection pool. If omitted and no
+  `backlog` option was provided, no pool will be created. If omitted
+  but `backlog` was provided, the pool will be created with a default
+  size equal to the value of the [lua_socket_pool_size](#lua_socket_pool_size)
+  directive.
+  The connection pool holds up to `pool_size` alive connections
+  ready to be reused by subsequent calls to [connect](#client:connect), but
+  note that there is no upper limit to the total number of opened connections
+  outside of the pool. If you need to restrict the total number of opened
+  connections, specify the `backlog` option.
+  When the connection pool would exceed its size limit, the least recently used
+  (kept-alive) connection already in the pool will be closed to make room for
+  the current connection.
+  Note that the cosocket connection pool is per Nginx worker process rather
+  than per Nginx server instance, so the size limit specified here also applies
+  to every single Nginx worker process. Also note that the size of the connection
+  pool cannot be changed once it has been created.
+  This option was first introduced in the `v0.10.14` release.
+
+* `backlog`
+
+  if specified, this module will limit the total number of opened connections
+  for this pool. No more connections than `pool_size` can be opened
+  for this pool at any time. If the connection pool is full, subsequent
+  connect operations will be queued into a queue equal to this option's
+  value (the "backlog" queue).
+  If the number of queued connect operations is equal to `backlog`,
+  subsequent connect operations will fail and return `nil` plus the
+  error string `"too many waiting connect operations"`.
+  The queued connect operations will be resumed once the number of connections
+  in the pool is less than `pool_size`.
+  The queued connect operation will abort once they have been queued for more
+  than `connect_timeout`, controlled by
+  [settimeouts](#client:set_timeout), and will return `nil` plus
+  the error string `"timeout"`.
+  This option was first introduced in the `v0.10.14` release.
 * `ssl_verify`
 
     Specifies whether to perform SSL certificate verification during the

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -2,7 +2,7 @@
 
 
 -- FIXME: this library is very rough and is currently just for testing
---        the websocket server.
+--        the websocket client.
 
 
 local wbproto = require "resty.websocket.protocol"

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -100,7 +100,7 @@ function _M.connect(self, uri, opts)
     end
 
     local ssl_verify, server_name, headers, proto_header, origin_header
-    local sock_opts = false
+    local sock_opts = {}
     local client_cert, client_priv_key
 
     if opts then
@@ -120,10 +120,17 @@ function _M.connect(self, uri, opts)
             origin_header = "\r\nOrigin: " .. origin
         end
 
-        local pool = opts.pool
-        if pool then
-            sock_opts = { pool = pool }
+        if opts.pool then
+            sock_opts.pool = opts.pool
         end
+        --pool_size specify the size of the connection pool. If omitted and no backlog option was provided, no pool will be created.
+        if opts.pool_size then
+            sock_opts.pool_size = opts.pool_size
+        end
+        if opts.backlog then
+            sock_opts.backlog = opts.backlog
+        end
+
 
         client_cert = opts.client_cert
         client_priv_key = opts.client_priv_key
@@ -149,14 +156,20 @@ function _M.connect(self, uri, opts)
         end
     end
 
-    local ok, err
-    if sock_opts then
-        ok, err = sock:connect(host, port, sock_opts)
-    else
-        ok, err = sock:connect(host, port)
-    end
+    local ok, err = sock:connect(host, port, sock_opts)
     if not ok then
         return nil, "failed to connect: " .. err
+    end
+
+    -- check for connections from pool:
+    local reused_count, err = sock:getreusedtimes()
+    if not reused_count then
+        return nil, "failed to get reused times: " .. tostring(err)
+    end
+
+    if reused_count > 0 then
+        -- being a reused connection (must have done handshake)
+        return 1
     end
 
     if scheme == "wss" then
@@ -173,17 +186,6 @@ function _M.connect(self, uri, opts)
         if not ok then
             return nil, "ssl handshake failed: " .. err
         end
-    end
-
-    -- check for connections from pool:
-
-    local count, err = sock:getreusedtimes()
-    if not count then
-        return nil, "failed to get reused times: " .. err
-    end
-    if count > 0 then
-        -- being a reused connection (must have done handshake)
-        return 1
     end
 
     local custom_headers


### PR DESCRIPTION
1. Add pool_size(optional) and backlog(optional) to the opts parameter to support opening the connection pool.
If omitted and no backlog option was provided, no pool will be created.
2. If the reused time of the connection exceeds 0, it means that sslhandshake has been performed.there is no need to repeat sslhandshake.