### PR TITLE
feature: custom sec-websocket-key in client

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -455,6 +455,10 @@ SSL handshake if the `wss://` scheme is used.
 
     Specifies the server name (SNI) to use when performing the TLS handshake with the server. If not provided, the `host` value or the `<host/addr>:<port>` from the connection URI will be used.
 
+* `key`
+
+    Specifies the value of the `Sec-WebSocket-Key` header in the handshake request. The value should be a base64-encoded, 16 byte string conforming to the client handshake requirements of the [WebSocket RFC](https://datatracker.ietf.org/doc/html/rfc6455#section-4.1). If not provided, a key is randomly generated.
+
 The SSL connection mode (`wss://`) requires at least `ngx_lua` 0.9.11 or OpenResty 1.7.4.1.
 
 [Back to TOC](#table-of-contents)

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -118,6 +118,7 @@ function _M.connect(self, uri, opts)
     local sock_opts = {}
     local client_cert, client_priv_key
     local header_host
+    local key
 
     if opts then
         local protos = opts.protocols
@@ -174,6 +175,11 @@ function _M.connect(self, uri, opts)
         if header_host ~= nil and type(header_host) ~= "string" then
             return nil, "custom host header must be a string"
         end
+
+        key = opts.key
+        if key ~= nil and type(key) ~= "string" then
+            return nil, "custom Sec-WebSocket-Key must be a string"
+        end
     end
 
     local ok, err
@@ -221,14 +227,16 @@ function _M.connect(self, uri, opts)
 
     -- do the websocket handshake:
 
-    local bytes = char(rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1, rand(256) - 1, rand(256) - 1,
-                       rand(256) - 1)
+    if not key then
+        local bytes = char(rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                           rand(256) - 1)
 
-    local key = encode_base64(bytes)
+        key = encode_base64(bytes)
+    end
 
     local host_header = header_host 
                         or (is_unix and "unix_sock" or addr .. ":" .. port)


### PR DESCRIPTION
This gives the caller the ability to explicitly set the value of the Sec-WebSocket-Key header instead of having it generated randomly.

This is useful when an OpenResty application is used for proxying WebSocket traffic with the requirement of maintaining a high degree of transparency.