### PR TITLE
doc: fix typo in comments

### DIFF
--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -2,7 +2,7 @@
 
 
 -- FIXME: this library is very rough and is currently just for testing
---        the websocket client.
+--        the websocket server.
 
 
 local wbproto = require "resty.websocket.protocol"


### PR DESCRIPTION
Until it matures, the client library is for testing the websocket server, not itself.

Fixes: 4d20e3041f1c ("bugfix: support socket connection pool and fix repeated ssl_handshake().")