### PR TITLE
feature: support ssl sockets for stream subsystem

### DIFF
--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -30,9 +30,9 @@ local ngx_DEBUG = ngx.DEBUG
 local assert = assert
 local ssl_support = true
 
-if not ngx.config
-    or not ngx.config.ngx_lua_version
-    or ngx.config.ngx_lua_version < 9011
+if not ngx.config.subsystem
+   and (not ngx.config.ngx_lua_version
+        or ngx.config.ngx_lua_version < 9011)
 then
     ssl_support = false
 end


### PR DESCRIPTION
Simplify and fix the ssl_support detection logic in the WebSocket client.

Previously, SSL was disabled whenever ngx_lua_version was absent or below 9011, regardless of subsystem — this incorrectly disabled SSL for stream subsystem. because the latest version of stream-lua-nginx-module is just 18.

Now SSL is only disabled when ngx.config.subsystem is absent (old builds without subsystem awareness) and the ngx_lua version is too old (< 0.9.11). stream-lua-nginx-module always support SSL sockets.