### PR TITLE
bugfix: client: reject a handshake response whose status is not 101

### DIFF
--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -276,9 +276,16 @@ function _M.connect(self, uri, opts)
 
     -- FIXME: verify the response headers
 
-    m, err = re_match(header, [[^\s*HTTP/1\.1\s+]], "jo")
+    m, err = re_match(header, [[^\s*HTTP/1\.1\s+(\d+)]], "jo")
     if not m then
         return nil, "bad HTTP response status line: " .. header
+    end
+
+    -- RFC 6455 section 4.1: a status code other than 101 means the server
+    -- has not accepted the upgrade, so the client must fail the connection
+    if m[1] ~= "101" then
+        return nil, "failed websocket handshake: unexpected response status: "
+                    .. m[1], header
     end
 
     return 1, nil, header

--- a/t/handshake.t
+++ b/t/handshake.t
@@ -1,0 +1,133 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * 9;
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "/usr/local/openresty-debug/lualib/?.so;/usr/local/openresty/lualib/?.so;;";
+};
+
+no_long_string();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: connect fails when the server refuses the upgrade with a 403
+--- http_config eval: $::HttpConfig
+--- config
+    location = /nows {
+        return 403;
+    }
+
+    location = /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            if not wb then
+                ngx.say("failed to new websocket: ", err)
+                return
+            end
+
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/nows"
+            local ok, err = wb:connect(uri)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected")
+        }
+    }
+--- request
+GET /t
+--- response_body
+failed to connect: failed websocket handshake: unexpected response status: 403
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: connect fails when the server answers with a redirect
+--- http_config eval: $::HttpConfig
+--- config
+    location = /nows {
+        return 301 http://example.com/;
+    }
+
+    location = /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            if not wb then
+                ngx.say("failed to new websocket: ", err)
+                return
+            end
+
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/nows"
+            local ok, err = wb:connect(uri)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected")
+        }
+    }
+--- request
+GET /t
+--- response_body
+failed to connect: failed websocket handshake: unexpected response status: 301
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: connect still succeeds against a real websocket server
+--- http_config eval: $::HttpConfig
+--- config
+    location = /ws {
+        content_by_lua_block {
+            local server = require "resty.websocket.server"
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+            wb:recv_frame()
+        }
+    }
+
+    location = /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            if not wb then
+                ngx.say("failed to new websocket: ", err)
+                return
+            end
+
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/ws"
+            local ok, err = wb:connect(uri)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected")
+            wb:send_close()
+        }
+    }
+--- request
+GET /t
+--- response_body
+connected
+--- no_error_log
+[error]


### PR DESCRIPTION
## What this fixes

`client:connect()` validates the handshake response with:

```lua
m, err = re_match(header, [[^\s*HTTP/1\.1\s+]], "jo")
```

Any HTTP/1.1 status line passes, so a server (or an intermediary that does not support `Upgrade`, e.g. a load balancer) answering `403`, `301`, or `502` is reported as a successfully connected WebSocket. The caller then writes masked frames into a plain HTTP connection and only finds out via garbage on the next `recv_frame()`, with no way to distinguish this from a transient network error and react (e.g. fall back to a non-WebSocket transport).

RFC 6455 section 4.1 requires the client to fail the connection whenever the handshake status is not `101`.

## Change

- `connect()` now captures the status code and returns `nil, "failed websocket handshake: unexpected response status: <code>", header` for anything other than `101`. The raw response header is still returned as the third value so callers can inspect the full response.
- Added `t/handshake.t`: refused upgrade (403), redirect (301), and a success control against `resty.websocket.server`.

Fixes #47 (open since 2019, asking for exactly this check, at the `FIXME: verify the response headers` site).

Related: #94 adds an opt-in `validate_handshake` option as part of a larger feature. This PR is only the minimal always-on status check: treating a non-101 response as a connected WebSocket is never correct, so it should apply by default rather than behind a flag. Happy to rebase either way if the maintainers prefer the #94 approach.